### PR TITLE
Colors: Use SCSS vars to define palette

### DIFF
--- a/assets/styles/alert.scss
+++ b/assets/styles/alert.scss
@@ -18,17 +18,17 @@
 }
 
 .alert--success {
-  background-color: var(--lime-500);
+  background-color: $LIME_500;
 }
 
 .alert--info {
-  background-color: var(--banana-300);
-  color: var(--black-900);
+  background-color: $BANANA_300;
+  color: $BLACK_900;
 }
 
 .alert--error {
-  background-color: var(--strawberry-500);
-  color: var(--silver-100);
+  background-color: $STRAWBERRY_500;
+  color: $SILVER_100;
 }
 
 .alert--bubble {

--- a/assets/styles/colors.scss
+++ b/assets/styles/colors.scss
@@ -1,72 +1,93 @@
-:root {
-  --strawberry-100: #ff8c82;
-  --strawberry-300: #ed5353;
-  --strawberry-500: #c6262e;
-  --strawberry-700: #a10705;
-  --strawberry-900: #7a0000;
-  --orange-100: #ffc27d;
-  --orange-300: #ffa154;
-  --orange-500: #f37329;
-  --orange-700: #cc3b02;
-  --orange-900: #a62100;
-  --banana-100: #fff394;
-  --banana-300: #ffe16b;
-  --banana-500: #f9c440;
-  --banana-700: #d48e15;
-  --banana-900: #ad5f00;
-  --lime-100: #d1ff82;
-  --lime-300: #9bdb4d;
-  --lime-500: #68b723;
-  --lime-700: #3a9104;
-  --lime-900: #206b00;
-  --blueberry-100: #8cd5ff;
-  --blueberry-300: #64baff;
-  --blueberry-500: #3689e6;
-  --blueberry-700: #0d52bf;
-  --blueberry-900: #002e99;
-  --grape-100: #e4c6fa;
-  --grape-300: #cd9ef7;
-  --grape-500: #a56de2;
-  --grape-700: #7239b3;
-  --grape-900: #452981;
-  --cocoa-100: #a3907c;
-  --cocoa-300: #8a715e;
-  --cocoa-500: #715344;
-  --cocoa-700: #57392d;
-  --cocoa-900: #3d211b;
-  --silver-100: #fafafa;
-  --silver-300: #d4d4d4;
-  --silver-500: #abacae;
-  --silver-700: #7e8087;
-  --silver-900: #555761;
-  --slate-100: #95a3ab;
-  --slate-300: #667885;
-  --slate-500: #485a6c;
-  --slate-700: #273445;
-  --slate-900: #0e141f;
-  --black-100: #666;
-  --black-300: #4d4d4d;
-  --black-500: #333;
-  --black-700: #1a1a1a;
-  --black-900: #000;
+$STRAWBERRY_100: #ff8c82;
+$STRAWBERRY_300: #ed5353;
+$STRAWBERRY_500: #c6262e;
+$STRAWBERRY_700: #a10705;
+$STRAWBERRY_900: #7a0000;
 
+$ORANGE_100: #ffc27d;
+$ORANGE_300: #ffa154;
+$ORANGE_500: #f37329;
+$ORANGE_700: #cc3b02;
+$ORANGE_900: #a62100;
+
+$BANANA_100: #fff394;
+$BANANA_300: #ffe16b;
+$BANANA_500: #f9c440;
+$BANANA_700: #d48e15;
+$BANANA_900: #ad5f00;
+
+$LIME_100: #d1ff82;
+$LIME_300: #9bdb4d;
+$LIME_500: #68b723;
+$LIME_700: #3a9104;
+$LIME_900: #206b00;
+
+$MINT_100: #89ffdd;
+$MINT_300: #43d6b5;
+$MINT_500: #28bca3;
+$MINT_700: #0e9a83;
+$MINT_900: #007367;
+
+$BLUEBERRY_100: #8cd5ff;
+$BLUEBERRY_300: #64baff;
+$BLUEBERRY_500: #3689e6;
+$BLUEBERRY_700: #0d52bf;
+$BLUEBERRY_900: #002e99;
+
+$BUBBLEGUM_100: #fe9ab8;
+$BUBBLEGUM_300: #f4679d;
+$BUBBLEGUM_500: #de3e80;
+$BUBBLEGUM_700: #bc245d;
+$BUBBLEGUM_900: #910e38;
+
+$GRAPE_100: #e4c6fa;
+$GRAPE_300: #cd9ef7;
+$GRAPE_500: #a56de2;
+$GRAPE_700: #7239b3;
+$GRAPE_900: #452981;
+
+$COCOA_100: #a3907c;
+$COCOA_300: #8a715e;
+$COCOA_500: #715344;
+$COCOA_700: #57392d;
+$COCOA_900: #3d211b;
+
+$SILVER_100: #fafafa;
+$SILVER_300: #d4d4d4;
+$SILVER_500: #abacae;
+$SILVER_700: #7e8087;
+$SILVER_900: #555761;
+
+$SLATE_100: #95a3ab;
+$SLATE_300: #667885;
+$SLATE_500: #485a6c;
+$SLATE_700: #273445;
+$SLATE_900: #0e141f;
+
+$BLACK_100: #666;
+$BLACK_300: #4d4d4d;
+$BLACK_500: #333;
+$BLACK_700: #1a1a1a;
+$BLACK_900: #000;
+
+:root {
   --bg-color: white;
-  --fg-color: var(--black-500);
-  --accent-color: var(--blueberry-700);
-  --header-bg-color: var(--blueberry-300);
-  --header-fg-color: var(--silver-100);
-  --secondary-bg-color: #f5f5f5; // Instead of making up a Silver 200
-  --secondary-fg-color: var(--black-300);
-  --warning-bg-color: var(--banana-300);
-  --warning-fg-color: var(--black-900);
+  --fg-color: #{$BLACK_500};
+  --accent-color: #{$GRAPE_700};
+  --header-bg-color: #{$GRAPE_700};
+  --header-fg-color: #{$SILVER_100};
+  --secondary-bg-color: #{mix($SILVER_100, $SILVER_300, 75%)};
+  --secondary-fg-color: #{"" + $BLACK_300};
+  --warning-bg-color: #{$BANANA_300};
+  --warning-fg-color: #{"" + $BLACK_900};
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg-color: var(--black-700);
-    --fg-color: var(--silver-300);
-    --accent-color: var(--blueberry-300);
-    --secondary-bg-color: var(--black-500);
-    --secondary-fg-color: var(--silver-300);
+    --bg-color: #{"" + $BLACK_700};
+    --fg-color: #{$SILVER_300};
+    --accent-color: #{$GRAPE_300};
+    --secondary-bg-color: #{"" + $BLACK_500};
+    --secondary-fg-color: #{$SILVER_300};
   }
 }


### PR DESCRIPTION
First PR towards #28! this replaces CSS vars for colors with SCSS vars so that we can use color transforms like mix. It also makes it easier to keep in sync with the OS stylesheet