### PR TITLE
Homepage: responsive work for small screens

### DIFF
--- a/assets/styles/pages/index.scss
+++ b/assets/styles/pages/index.scss
@@ -4,8 +4,9 @@
   color: white;
   display: flex;
   flex-direction: column;
+  text-align: center;
   text-shadow: 0 1px 2px rgba(black, 0.3);
-  padding: 6em 0 10em;
+  padding: 6em 1em 10em;
   row-gap: 1em;
 
   h1,
@@ -27,27 +28,49 @@
   display: flex;
   grid-gap: 2em;
   flex-direction: row;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  justify-content: center;
   margin: -7em auto 0 auto;
   max-width: var(--page-width);
   padding-top: 3em;
   padding-bottom: 3em;
 
-  .card h2 {
-    color: var(--accent-color);
-    text-align: center;
+  @media (min-width: 700px) {
+    flex-wrap: nowrap;
+  }
+
+  .card {
+    flex-grow: 1;
+    margin-left: auto;
+    margin-right: auto;
+    // Line length feels too wide past here
+    max-width: 25rem;
+
+    h2 {
+      color: var(--accent-color);
+      text-align: center;
+    }
   }
 }
 
 .pitch-appcenter {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   grid-gap: 3em;
   justify-content: space-between;
   margin: 0 auto;
   max-width: var(--page-width);
   padding-bottom: 6em;
   padding-top: 6em;
+
+  @media (min-width: 700px) {
+    flex-wrap: nowrap;
+
+    div:first-child {
+      order: 2;
+    }
+  }
 
   div {
     flex-basis: 100%;

--- a/assets/styles/pages/index.scss
+++ b/assets/styles/pages/index.scss
@@ -29,7 +29,7 @@
   grid-gap: 2em;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: space-between;
   margin: -7em auto 0 auto;
   max-width: var(--page-width);
   padding-top: 3em;

--- a/lib/appcenter_dashboard_web/templates/homepage/index.html.eex
+++ b/lib/appcenter_dashboard_web/templates/homepage/index.html.eex
@@ -24,6 +24,9 @@
 
 <section class="pitch-appcenter">
   <div>
+    <img alt="Screenshot of AppCenter" src="/images/appcenter-screenshot.png">
+  </div>
+  <div>
     <h2>Get In Front of Users</h2>
     <ul>
       <li>New apps get featured with a large, branded banner. Plus, trending and recently-updated apps are featured on the front page.</li>
@@ -31,8 +34,5 @@
       <li>With built-in social media sharing and app URLs, users can easily share your app right from AppCenter.</li>
     </ul>
     <a class="read-more" href="https://docs.elementary.io/develop/writing-apps/untitled#the-desktop-file" target="_blank">Learn more about app metadata</a>
-  </div>
-  <div>
-    <img src="/images/appcenter-screenshot.png">
   </div>
 </section>


### PR DESCRIPTION
Makes things a bit better on small screens like mobile.

- Stacks/wraps the cards up until a reasonable size
- Stacks the AppCenter screenshot above the text copy until a reasonable width, then pushes it back to the right