### PR TITLE
init project genserver

### DIFF
--- a/lib/appcenter_dashboard/application.ex
+++ b/lib/appcenter_dashboard/application.ex
@@ -11,6 +11,10 @@ defmodule Elementary.AppcenterDashboard.Application do
     children = [
       # Start the HTTP client pools
       {Finch, name: FinchPool},
+      # Start the Project supervisor and registry
+      {Registry, keys: :unique, name: Elementary.AppcenterDashboard.ProjectRegistry},
+      {DynamicSupervisor,
+       strategy: :one_for_one, name: Elementary.AppcenterDashboard.ProjectSupervisor},
       # Start the Appstream parsing process
       {Elementary.AppcenterDashboard.Appstream, appstream_config},
       # Start the Telemetry supervisor

--- a/lib/appcenter_dashboard/appstream.ex
+++ b/lib/appcenter_dashboard/appstream.ex
@@ -6,6 +6,12 @@ defmodule Elementary.AppcenterDashboard.Appstream do
 
   use GenServer
 
+  @type appstream_data :: %{
+          name: String.t(),
+          rdnn: String.t(),
+          icon: String.t()
+        }
+
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
   end
@@ -25,7 +31,7 @@ defmodule Elementary.AppcenterDashboard.Appstream do
 
   @impl true
   def handle_call({:find, rdnn}, _from, state) do
-    found_appstream = Enum.find(state.appstream, &(&1.rdnn == rdnn))
+    found_appstream = Enum.find(state.data, &(&1.rdnn == rdnn))
     {:reply, found_appstream, state}
   end
 
@@ -57,12 +63,12 @@ defmodule Elementary.AppcenterDashboard.Appstream do
 
     File.rmdir(local_dir)
 
-    Process.send_after(self(), :refresh, 24 * 60 * 60 * 1000)
+    Process.send_after(self(), :refresh, 15 * 60 * 1000)
 
     {:noreply, Map.put(state, :data, appstream_data)}
   end
 
-  defp parse_appstream_data(component, config) do
+  defp parse_appstream_data(component, state) do
     name =
       component
       |> Floki.find("name")
@@ -88,7 +94,7 @@ defmodule Elementary.AppcenterDashboard.Appstream do
 
     icon_path =
       if icon_filename != "",
-        do: Path.join([config.opts[:icons], "64x64", icon_filename]),
+        do: Path.join([state.opts[:icons], "64x64", icon_filename]),
         else: nil
 
     %{

--- a/lib/appcenter_dashboard/project.ex
+++ b/lib/appcenter_dashboard/project.ex
@@ -5,6 +5,16 @@ defmodule Elementary.AppcenterDashboard.Project do
   Appstream data from the flatpak repository, and user input.
   """
 
+  defstruct [
+    :name,
+    :rdnn,
+    :icon,
+    :released_version,
+    :released_at,
+    :reviewing_version,
+    :reviewing_at
+  ]
+
   use GenServer
 
   alias Elementary.AppcenterDashboard.Appstream
@@ -13,6 +23,15 @@ defmodule Elementary.AppcenterDashboard.Project do
   @supervisor Elementary.AppcenterDashboard.ProjectSupervisor
 
   @type rdnn :: String.t()
+  @type t :: %{
+          name: String.t(),
+          rdnn: rdnn,
+          icon: String.t(),
+          released_version: Version.t(),
+          released_at: DateTime.t(),
+          reviewing_version: Version.t(),
+          reviewing_at: DateTime.t()
+        }
 
   @doc """
   Starts a new project process to monitor information about the project.
@@ -51,6 +70,18 @@ defmodule Elementary.AppcenterDashboard.Project do
   end
 
   @doc """
+  Grabs information about the project
+  """
+  @spec info(pid()) :: t()
+  def info(pid), do: GenServer.call(pid, :info)
+
+  @doc """
+  Updates information about a project
+  """
+  @spec update(pid(), map) :: :ok
+  def update(pid, info), do: GenServer.call(pid, {:update, info})
+
+  @doc """
   Starts a new GenServer project process.
   """
   @spec start_link(Keyword.t()) :: {:ok, pid()}
@@ -63,12 +94,22 @@ defmodule Elementary.AppcenterDashboard.Project do
   Runs right after the new process is created. Fetches the initial data for
   the project.
   """
+  @impl true
   def init(opts) do
-    state = %{
-      rdnn: Keyword.fetch!(opts, :rdnn),
-      last_change: DateTime.utc_now()
-    }
+    {:ok,
+     %__MODULE__{
+       rdnn: Keyword.fetch!(opts, :rdnn)
+     }}
+  end
 
-    {:ok, state}
+  @impl true
+  def handle_call(:info, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_call({:update, new_info}, _from, state) do
+    updated_state = struct(state, new_info)
+    {:reply, updated_state, updated_state}
   end
 end

--- a/lib/appcenter_dashboard/project.ex
+++ b/lib/appcenter_dashboard/project.ex
@@ -1,0 +1,74 @@
+defmodule Elementary.AppcenterDashboard.Project do
+  @moduledoc """
+  Handles grabbing information about projects. This information is persisted and
+  aggregated from multiple sources, like GitHub open Pull Requests, published
+  Appstream data from the flatpak repository, and user input.
+  """
+
+  use GenServer
+
+  alias Elementary.AppcenterDashboard.Appstream
+
+  @registry Elementary.AppcenterDashboard.ProjectRegistry
+  @supervisor Elementary.AppcenterDashboard.ProjectSupervisor
+
+  @type rdnn :: String.t()
+
+  @doc """
+  Starts a new project process to monitor information about the project.
+  """
+  @spec start_pid(rdnn) :: {:ok, pid()}
+  def start_pid(rdnn) do
+    DynamicSupervisor.start_child(
+      @supervisor,
+      {__MODULE__,
+       [
+         rdnn: rdnn,
+         name: {:via, Registry, {@registry, rdnn}}
+       ]}
+    )
+  end
+
+  @doc """
+  Lookups the PID for a project process.
+  """
+  @spec lookup_pid(rdnn) :: {:ok, pid()} | {:error, :not_found}
+  def lookup_pid(rdnn) do
+    case Registry.lookup(@registry, rdnn) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Finds the existing PID, or creates a new process and returns that PID.
+  """
+  @spec find_or_start_pid(rdnn) :: {:ok, pid()}
+  def find_or_start_pid(rdnn) do
+    with {:error, :not_found} <- lookup_pid(rdnn) do
+      start_pid(rdnn)
+    end
+  end
+
+  @doc """
+  Starts a new GenServer project process.
+  """
+  @spec start_link(Keyword.t()) :: {:ok, pid()}
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Runs right after the new process is created. Fetches the initial data for
+  the project.
+  """
+  def init(opts) do
+    state = %{
+      rdnn: Keyword.fetch!(opts, :rdnn),
+      last_change: DateTime.utc_now()
+    }
+
+    {:ok, state}
+  end
+end

--- a/lib/appcenter_dashboard/services/github.ex
+++ b/lib/appcenter_dashboard/services/github.ex
@@ -1,0 +1,42 @@
+defmodule Elementary.AppcenterDashboard.GitHubService do
+  @moduledoc """
+  A wrapper for GitHub API calls.
+  """
+
+  @doc """
+  Grabs all of the open PR titles in the review repository.
+
+  ## Examples
+
+    iex> open_reviews()
+    ["Release com.github.elementary.calculator 3.1.4"]
+
+  """
+  def open_reviews() do
+  end
+
+  @doc """
+  Grabs the latest release version for a GitHub repository.
+
+  ## Examples
+
+    iex> latest_version("elementary/camera")
+    {:ok, %Version{}}
+
+    iex> latest_version("ignore/nonexistance")
+    {:ok, nil}
+
+  """
+  def latest_version(slug) do
+    request = Finch.build(:get, "https://api.github.com/repos/#{slug}/releases/latest")
+
+    with {:ok, response} <- Finch.request(request, FinchPool),
+         version_tag <- Map.get(response, "tag_name", ""),
+         {:ok, version} <- Version.parse(version_tag) do
+      version
+    else
+      {:error, 404} -> {:ok, nil}
+      :error -> {:ok, nil}
+    end
+  end
+end


### PR DESCRIPTION
Starts work on a project `GenServer`. This will be responsible for aggregating information about a project from appstream, github PRs, and anything else.

