### PR TITLE
Trim leading 'v' while parsing version tags

### DIFF
--- a/lib/appcenter_dashboard/repository.ex
+++ b/lib/appcenter_dashboard/repository.ex
@@ -83,7 +83,7 @@ defmodule Elementary.AppcenterDashboard.Repository do
       rdnn: rdnn,
       source: source,
       commit: Map.get(file, "commit"),
-      released_version: file |> Map.get("version") |> Version.parse!()
+      released_version: file |> Map.get("version") |> String.trim_leading("v") |> Version.parse!()
     }
   end
 

--- a/lib/appcenter_dashboard/services/github_service.ex
+++ b/lib/appcenter_dashboard/services/github_service.ex
@@ -42,7 +42,7 @@ defmodule Elementary.AppcenterDashboard.GitHubService do
     with {:ok, %{status: status, body: body}} when status in 200..299 <-
            get_latest_release(connection),
          version_tag <- Map.get(body, "tag_name", ""),
-         {:ok, version} <- Version.parse(version_tag) do
+         {:ok, version} <- version_tag |> String.trim_leading("v") |> Version.parse() do
       {:ok, version}
     else
       {:ok, %{status: 404}} -> {:error, "Project does not have a stable release"}


### PR DESCRIPTION
Closes #60.

This change trims away the 'v' in version tags before calling `Version.parse/1`.

It fixes the `docker-compose up` error I mentioned in #60, and also the original issue reported by @ChildishGiant, ~but I couldn't test it~.

`docker-compose up` prints the following output, with no errors, but when I hit `localhost:4000` in a browser, nothing shows up:

```
Starting appcenter-dashboard_dashboard_1 ... done
Attaching to appcenter-dashboard_dashboard_1
dashboard_1  | Compiling 1 file (.ex)
dashboard_1  | [info] Running Elementary.AppcenterDashboardWeb.Endpoint with cowboy 2.9.0 at 0.0.0.0:4000 (http)
dashboard_1  | [info] Access Elementary.AppcenterDashboardWeb.Endpoint at http://localhost:4000
```

Disclosure: I am very new to both Elixir and Docker, and am doing this on a Mac.