### PR TITLE
Fix "team" link in footer

### DIFF
--- a/lib/appcenter_dashboard_web/templates/layout/footer.html.eex
+++ b/lib/appcenter_dashboard_web/templates/layout/footer.html.eex
@@ -32,7 +32,7 @@
   </li>
 
   <li>
-    <a href="https://elementary.io/team" target="_self">
+    <a href="https://github.com/orgs/elementary/people" target="_self">
       <%= dgettext "layout", "Team" %>
     </a>
   </li>


### PR DESCRIPTION
Same change as https://github.com/elementary/website/pull/3271