### PR TITLE
patch: layout on mobile

### DIFF
--- a/assets/styles/pages/index.scss
+++ b/assets/styles/pages/index.scss
@@ -96,7 +96,7 @@
 }
 
 .monetize {
-  @media (min-width: 700px) {
+  @media (min-width: 992px) {
     padding-top: 6em;
     padding-bottom: 6em;
   }

--- a/assets/styles/pages/index.scss
+++ b/assets/styles/pages/index.scss
@@ -78,7 +78,6 @@
 
   h2 {
     margin: 0;
-    text-align: left;
   }
 
   ul {
@@ -97,11 +96,15 @@
 }
 
 .monetize {
+  @media (min-width: 700px) {
+    padding-top: 6em;
+    padding-bottom: 6em;
+  }
   background-color: var(--secondary-bg-color);
   display: grid;
   grid-gap: 3em 1em;
-  padding-bottom: 6em;
-  padding-top: 6em;
+  padding-bottom: 0.25em;
+  padding-top: 3em;
 
   > h2 {
     margin: 0 auto;
@@ -109,7 +112,10 @@
   }
 
   > div {
-    display: flex;
+    @media (min-width: 992px) {
+      display: flex;
+      padding-bottom: 0;
+    }
     grid-gap: 6em;
     flex-direction: row;
     justify-content: space-between;
@@ -123,6 +129,7 @@
         display: block;
         margin-top: 2em;
         text-align: center;
+        padding-bottom: 2em;
       }
 
       .card {

--- a/assets/styles/pages/index.scss
+++ b/assets/styles/pages/index.scss
@@ -100,6 +100,7 @@
     padding-top: 6em;
     padding-bottom: 6em;
   }
+
   background-color: var(--secondary-bg-color);
   display: grid;
   grid-gap: 3em 1em;
@@ -116,6 +117,7 @@
       display: flex;
       padding-bottom: 0;
     }
+
     grid-gap: 6em;
     flex-direction: row;
     justify-content: space-between;


### PR DESCRIPTION
Closes #244

## Description
Currently, on mobile devices, the homepage has layout issues which cause the app to look odd and have part of the content cut-off.

This PR addresses that by some slight CSS tweaks. The main culprit was a display flex in the monetize div section which is necessary for larger devices but not for small for the layout. Outside of that, some slight padding items were tweaked to improve the look on mobile.

### Before
<img width="839" height="1005" alt="image" src="https://github.com/user-attachments/assets/4f55fc85-a575-48eb-886b-473065f13fe9" />
<img width="838" height="919" alt="image" src="https://github.com/user-attachments/assets/b417e2fa-09b5-4b8e-bdf5-845123d2e32a" />
<img width="839" height="969" alt="image" src="https://github.com/user-attachments/assets/3ef07df9-00e9-4c1a-83c8-6299da46a0b1" />
<img width="839" height="915" alt="image" src="https://github.com/user-attachments/assets/f1efcead-6182-48e7-a408-6ab62607a985" />

### After
<img width="971" height="905" alt="image" src="https://github.com/user-attachments/assets/db4f3aec-b355-417f-ae34-127e8bda593c" />
<img width="968" height="869" alt="image" src="https://github.com/user-attachments/assets/58e643fb-98b1-4598-b4ff-9df362b71786" />
<img width="972" height="917" alt="image" src="https://github.com/user-attachments/assets/913c8802-6f71-48fd-8f3f-c8af04b45fb9" />
<img width="971" height="867" alt="image" src="https://github.com/user-attachments/assets/53be6ea1-b644-464d-be53-5ec72b146382" />



### Additional Info
992px media sizing came from a breakpoint found in bootstrap css framework for large devices.

https://getbootstrap.com/docs/4.0/layout/overview/

